### PR TITLE
Fix saving preferences and share calendar

### DIFF
--- a/web/application/controllers/calendar.php
+++ b/web/application/controllers/calendar.php
@@ -318,7 +318,7 @@ class Calendar extends MY_Controller
                     $this->shared_calendars->store(
                             $this_sid,
                             $this->user->getUsername(),
-                            $internal_calendar,
+                            $calendar,
                             $share['username'],
                             null,                   // Preserve options
                             $share['rw']);

--- a/web/application/controllers/prefs.php
+++ b/web/application/controllers/prefs.php
@@ -107,7 +107,7 @@ class Prefs extends MY_Controller
      */
     function save() {
         $calendar = $this->input->post('calendar', true);
-        $default_calendar = $this->input->post('default_calendar, true');
+        $default_calendar = $this->input->post('default_calendar', true);
 
         if (!is_array($calendar)) {
             log_message('ERROR',


### PR DESCRIPTION
- Fix typo in the code, causing error "ERROR: Preferences save attempt with default_calendar not set" when trying to save preferences
- Solve AgenDAV issue #94 (cannot share calendar due to wrong variable name)
