### PR TITLE
sanitize trim($year) to avoid PHP warning

### DIFF
--- a/web/lib/iCalcreator/iCalcreator.class.php
+++ b/web/lib/iCalcreator/iCalcreator.class.php
@@ -8635,7 +8635,7 @@ class iCalUtilityFunctions {
       $parno           = iCalUtilityFunctions::_existRem( $input['params'], 'VALUE', 'DATE-TIME', $hitval, $parno );
       $input['value']  = iCalUtilityFunctions::_timestamp2date( $year, $parno );
     }
-    elseif( 8 <= strlen( trim( $year ))) { // ex. 2006-08-03 10:12:18
+    elseif( is_string($year) && ( 8 <= strlen( trim( $year )))) { // ex. 2006-08-03 10:12:18
       if( $localtime ) unset ( $month['VALUE'], $month['TZID'] );
       $input['params'] = iCalUtilityFunctions::_setParams( $month, array( 'VALUE' => 'DATE-TIME' ));
       if( isset( $input['params']['TZID'] )) {


### PR DESCRIPTION
The fact trim($year) was called without sanitization leads to log errors like:

```
ERROR - 2015-01-17 08:30:29 --> Severity: Warning  --> trim() expects parameter 1 to be string, array given /var/www/agendav/libs/icalcreator/iCalcreator.class.php 8639
```

While adding an event to the calendar from web interface.

Even worse, this output was bundled in the *POST* request response for event creation :

```
<p>Severity: Warning</p>
<p>Message:  trim() expects parameter 1 to be string, array given</p>
<p>Filename: icalcreator/iCalcreator.class.php</p>
<p>Line Number: 8638</p>
<p>Severity: Warning</p>
<p>Message:  trim() expects parameter 1 to be string, array given</p>
<p>Filename: icalcreator/iCalcreator.class.php</p>
<p>Line Number: 8638</p>
```

which leads to json parsing error.

This PR fixes that.