### PR TITLE
Fix ansible SSL issue with github.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Etags were not being updated after dropping/resizing an event
+- Work around ansible bug #12161 when downloading baikal in the development machine
 
 ## [2.0.0-beta2] - 2016-04-20
 

--- a/ansible/baikal.yml
+++ b/ansible/baikal.yml
@@ -2,7 +2,7 @@
 # Baikal installation
 
   - name: download baikal
-    get_url: url=https://github.com/fruux/Baikal/releases/download/0.4.6/baikal-0.4.6.zip dest=/tmp/baikal.zip
+    command: wget -q -O /tmp/baikal.zip https://github.com/fruux/Baikal/releases/download/0.4.6/baikal-0.4.6.zip
 
   - name: unzip baikal
     command: /usr/bin/unzip /tmp/baikal.zip -d /var/www


### PR DESCRIPTION
See for example https://github.com/ansible/ansible/issues/12161

There are numerous ansible issues reported with the following message :
  msg: Failed to validate the SSL certificate for domain.tld:443. Use validate_certs=False or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible

It seems to be caused by python <2.7.9 not supporting SNI
Running the baikal playbook on ubuntu trusty, with default python-2.7 which is 2.7.6,
we run into this error.
As noted in the issue, using curl/wget works.