### PR TITLE
Fix access to files when deployed in subdirectory

### DIFF
--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>{{ title }}</title>
-        <link rel="shortcut icon" type="image/x-icon" href="{{ app.request.basepath }}favicon.ico" />
+        <link rel="shortcut icon" type="image/x-icon" href="{{ app.request.basepath }}/favicon.ico" />
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
         {% if stylesheets is defined %}
             {% for stylesheet in stylesheets %}
@@ -16,7 +16,7 @@
             {% endfor %}
         {% endif %}
 <!--[if lt IE 9]>
-<script src="{{ app.request.basepath }}js/libs/es5-shim.js"></script>
+<script src="{{ app.request.basepath }}/js/libs/es5-shim.js"></script>
 <![endif]-->
     </head>
     <body>


### PR DESCRIPTION
When deployed to a subdir, the app.request.basepath variable
does not contain an ending slash.
This prevents the favico to load.
Fix it by preprending a slash.

Also fix a similar issue when loading es5-shim.js

The other assets were not affected because they already got
a prepending slash.